### PR TITLE
Lock player column to prevent editing player names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project dependencies
 .cache
+.idea
 node_modules
 yarn-error.log
 
@@ -27,7 +28,4 @@ awsmobilejs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# IntelliJ Settings
-.idea
 

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,22 +2,11 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="f79fec04-6f74-4a22-8cbe-3c18fb3db3c0" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/src/components/AdminStatsTable.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/layouts/layouts.css" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/utils/Utils.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/AdminEntryForm.js" beforeDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/AdminSideMenu.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/AdminSideMenu.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/Header.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/Header.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/PlayerStatForm.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/StatHeaders.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/components.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/layouts/index.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/layouts/index.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/layouts/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/layouts/index.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/pages/Admin.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/pages/Admin.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/pages/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/pages/index.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/yarn.lock" beforeDir="false" afterPath="$PROJECT_DIR$/yarn.lock" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/AdminStatsTable.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/AdminStatsTable.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/utils/Utils.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/utils/Utils.js" afterDir="false" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
@@ -40,10 +29,10 @@
       <usages-collector id="statistics.file.extensions.open">
         <counts>
           <entry key="css" value="29" />
-          <entry key="gitignore" value="1" />
+          <entry key="gitignore" value="2" />
           <entry key="html" value="3" />
-          <entry key="js" value="116" />
-          <entry key="json" value="16" />
+          <entry key="js" value="128" />
+          <entry key="json" value="24" />
           <entry key="map" value="1" />
           <entry key="md" value="2" />
           <entry key="prettierrc" value="1" />
@@ -55,10 +44,10 @@
         <counts>
           <entry key="CSS" value="29" />
           <entry key="HTML" value="3" />
-          <entry key="JSON" value="16" />
-          <entry key="JavaScript" value="116" />
+          <entry key="JSON" value="24" />
+          <entry key="JavaScript" value="128" />
           <entry key="Markdown" value="2" />
-          <entry key="PLAIN_TEXT" value="2" />
+          <entry key="PLAIN_TEXT" value="3" />
           <entry key="SVG" value="1" />
           <entry key="SourceMap" value="1" />
           <entry key="YAML" value="2" />
@@ -66,20 +55,20 @@
       </usages-collector>
       <usages-collector id="statistics.file.extensions.edit">
         <counts>
-          <entry key="css" value="1087" />
-          <entry key="gitignore" value="1" />
-          <entry key="js" value="8999" />
+          <entry key="css" value="1140" />
+          <entry key="gitignore" value="2" />
+          <entry key="js" value="9234" />
           <entry key="json" value="19" />
           <entry key="md" value="1459" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.types.edit">
         <counts>
-          <entry key="CSS" value="1087" />
+          <entry key="CSS" value="1140" />
           <entry key="JSON" value="19" />
-          <entry key="JavaScript" value="8999" />
+          <entry key="JavaScript" value="9234" />
           <entry key="Markdown" value="1459" />
-          <entry key="PLAIN_TEXT" value="1" />
+          <entry key="PLAIN_TEXT" value="2" />
         </counts>
       </usages-collector>
     </session>
@@ -89,26 +78,34 @@
       <split-first>
         <leaf>
           <file pinned="false" current-in-tab="false">
-            <entry file="file://$PROJECT_DIR$/src/components/AdminStatsTable.js">
+            <entry file="file://$PROJECT_DIR$/awsmobilejs/backend/cloud-api/playerstats/app.js">
               <provider selected="true" editor-type-id="text-editor">
-                <state relative-caret-position="326">
-                  <caret line="154" column="40" selection-start-line="154" selection-start-column="40" selection-end-line="154" selection-end-column="40" />
+                <state relative-caret-position="288">
+                  <caret line="67" column="9" lean-forward="true" selection-start-line="67" selection-start-column="9" selection-end-line="67" selection-end-column="9" />
                   <folding>
-                    <element signature="e#0#26#0" expanded="true" />
-                    <element signature="e#1494#3052#0" />
+                    <element signature="n#!!doc" expanded="true" />
+                  </folding>
+                </state>
+              </provider>
+            </entry>
+          </file>
+          <file pinned="false" current-in-tab="false">
+            <entry file="file://$PROJECT_DIR$/src/pages/index.js">
+              <provider selected="true" editor-type-id="text-editor">
+                <state relative-caret-position="378">
+                  <caret line="18" lean-forward="true" selection-start-line="18" selection-end-line="18" />
+                  <folding>
+                    <element signature="e#0#25#0" expanded="true" />
                   </folding>
                 </state>
               </provider>
             </entry>
           </file>
           <file pinned="false" current-in-tab="true">
-            <entry file="file://$PROJECT_DIR$/src/components/AdminSideMenu.js">
+            <entry file="file://$PROJECT_DIR$/.gitignore">
               <provider selected="true" editor-type-id="text-editor">
-                <state relative-caret-position="294">
-                  <caret line="14" selection-start-line="14" selection-end-line="14" />
-                  <folding>
-                    <element signature="e#0#26#0" expanded="true" />
-                  </folding>
+                <state relative-caret-position="588">
+                  <caret line="28" column="4" lean-forward="true" selection-start-line="28" selection-start-column="4" selection-end-line="28" selection-end-column="4" />
                 </state>
               </provider>
             </entry>
@@ -117,11 +114,26 @@
       </split-first>
       <split-second>
         <leaf>
-          <file pinned="false" current-in-tab="true">
-            <entry file="file://$PROJECT_DIR$/src/components/components.css">
+          <file pinned="false" current-in-tab="false">
+            <entry file="file://$PROJECT_DIR$/src/pages/Admin.js">
               <provider selected="true" editor-type-id="text-editor">
-                <state relative-caret-position="599">
-                  <caret line="37" column="21" selection-start-line="37" selection-start-column="21" selection-end-line="37" selection-end-column="21" />
+                <state relative-caret-position="378">
+                  <caret line="18" column="5" lean-forward="true" selection-start-line="18" selection-start-column="5" selection-end-line="18" selection-end-column="5" />
+                  <folding>
+                    <element signature="e#0#26#0" expanded="true" />
+                  </folding>
+                </state>
+              </provider>
+            </entry>
+          </file>
+          <file pinned="false" current-in-tab="true">
+            <entry file="file://$PROJECT_DIR$/src/components/AdminStatsTable.js">
+              <provider selected="true" editor-type-id="text-editor">
+                <state relative-caret-position="470">
+                  <caret line="26" column="16" lean-forward="true" selection-start-line="26" selection-start-column="16" selection-end-line="26" selection-end-column="16" />
+                  <folding>
+                    <element signature="e#0#26#0" expanded="true" />
+                  </folding>
                 </state>
               </provider>
             </entry>
@@ -147,7 +159,6 @@
       <list>
         <option value="$PROJECT_DIR$/README.md" />
         <option value="$PROJECT_DIR$/gatsby-config.js" />
-        <option value="$PROJECT_DIR$/.gitignore" />
         <option value="$PROJECT_DIR$/src/pages/page-2.js" />
         <option value="$PROJECT_DIR$/src/components/header.js" />
         <option value="$PROJECT_DIR$/src/components/playerStatRow.js" />
@@ -162,7 +173,6 @@
         <option value="$PROJECT_DIR$/src/pages/pages.css" />
         <option value="$PROJECT_DIR$/src/components/StatHeaders.js" />
         <option value="$PROJECT_DIR$/src/components/PlayerStatForm.js" />
-        <option value="$PROJECT_DIR$/src/utils/Utils.js" />
         <option value="$PROJECT_DIR$/src/pages/StatTableEditMode.js" />
         <option value="$PROJECT_DIR$/src/pages/index.js" />
         <option value="$PROJECT_DIR$/src/layouts/index.css" />
@@ -173,8 +183,10 @@
         <option value="$PROJECT_DIR$/src/components/StatTableEditMode.js" />
         <option value="$PROJECT_DIR$/src/pages/Admin.js" />
         <option value="$PROJECT_DIR$/src/components/components.css" />
-        <option value="$PROJECT_DIR$/src/components/AdminStatsTable.js" />
+        <option value="$PROJECT_DIR$/src/utils/Utils.js" />
         <option value="$PROJECT_DIR$/src/components/AdminSideMenu.js" />
+        <option value="$PROJECT_DIR$/src/components/AdminStatsTable.js" />
+        <option value="$PROJECT_DIR$/.gitignore" />
       </list>
     </option>
   </component>
@@ -203,9 +215,10 @@
     </packageJsonPaths>
   </component>
   <component name="ProjectFrameBounds">
-    <option name="y" value="23" />
-    <option name="width" value="1440" />
-    <option name="height" value="822" />
+    <option name="x" value="1443" />
+    <option name="y" value="-189" />
+    <option name="width" value="1898" />
+    <option name="height" value="1144" />
   </component>
   <component name="ProjectView">
     <navigator proportions="" version="1">
@@ -342,18 +355,18 @@
       <workItem from="1537388567211" duration="1213000" />
       <workItem from="1537469254235" duration="494000" />
       <workItem from="1537476384382" duration="595000" />
-      <workItem from="1537490767683" duration="29520000" />
+      <workItem from="1537490767683" duration="35946000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="114995000" />
+    <option name="totallyTimeSpent" value="121421000" />
   </component>
   <component name="ToolWindowManager">
-    <frame x="0" y="23" width="1440" height="822" extended-state="0" />
+    <frame x="1443" y="-189" width="1898" height="1144" extended-state="0" />
     <editor active="true" />
     <layout>
-      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.20600858" />
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.20581897" />
       <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
       <window_info id="Designer" order="2" />
       <window_info id="UI Designer" order="3" />
@@ -409,41 +422,11 @@
     <entry file="file://$PROJECT_DIR$/src/pages/404.js">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/.gitignore">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="357">
-          <caret line="17" column="11" selection-start-line="17" selection-start-column="11" selection-end-line="17" selection-end-column="11" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/.prettierrc">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="105">
           <caret line="5" lean-forward="true" selection-start-line="5" selection-end-line="5" />
         </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/project-info.json">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/project-config.json">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/aws-info.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="147">
-          <caret line="7" selection-start-line="7" selection-end-line="7" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/aws-exports.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-116" />
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/backend-details.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-5807" />
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/mobile-hub-project.yml">
@@ -460,13 +443,6 @@
     <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/cloud-api/playerstats/package-lock.json">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="-6505" />
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/cloud-api/playerstats/app.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="178">
-          <caret line="199" column="3" lean-forward="true" selection-start-line="199" selection-start-column="3" selection-end-line="199" selection-end-column="3" />
-        </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/components/Styles.js">
@@ -486,13 +462,6 @@
     <entry file="file://$PROJECT_DIR$/public/index.html">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/package.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="42">
-          <caret line="2" column="40" lean-forward="true" selection-start-line="2" selection-start-column="40" selection-end-line="2" selection-end-column="40" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/gatsby-config.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="42">
@@ -500,27 +469,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/utils/Utils.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="94">
-          <caret line="51" column="28" lean-forward="true" selection-start-line="51" selection-start-column="28" selection-end-line="51" selection-end-column="28" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/pages/pages.css">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="42">
           <caret line="2" column="1" selection-start-line="2" selection-start-column="1" selection-end-line="2" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/pages/index.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="126">
-          <caret line="6" lean-forward="true" selection-start-line="6" selection-end-line="6" />
-          <folding>
-            <element signature="e#0#25#0" expanded="true" />
-          </folding>
         </state>
       </provider>
     </entry>
@@ -588,41 +540,112 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/pages/Admin.js">
+    <entry file="file://$PROJECT_DIR$/src/components/components.css">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-3">
-          <caret line="15" column="32" lean-forward="true" selection-start-line="15" selection-start-column="32" selection-end-line="15" selection-end-column="32" />
+        <state relative-caret-position="467">
+          <caret line="31" lean-forward="true" selection-start-line="31" selection-end-line="31" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/package.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="315">
+          <caret line="15" column="4" lean-forward="true" selection-start-line="15" selection-start-column="4" selection-end-line="15" selection-end-column="4" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/backend-details.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-5862" />
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/aws-exports.js">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/#current-backend-info/cloud-api/playerstats/app.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="199">
+          <caret line="200" lean-forward="true" selection-start-line="200" selection-end-line="200" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/project-info.json">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/project-config.json">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/.awsmobile/info/aws-info.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="147">
+          <caret line="7" selection-start-line="7" selection-end-line="7" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/aws-exports.js">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/components/AdminSideMenu.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="315">
+          <caret line="15" lean-forward="true" selection-start-line="15" selection-end-line="15" />
           <folding>
             <element signature="e#0#26#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/components/components.css">
+    <entry file="file://$PROJECT_DIR$/src/utils/Utils.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="599">
-          <caret line="37" column="21" selection-start-line="37" selection-start-column="21" selection-end-line="37" selection-end-column="21" />
+        <state relative-caret-position="298">
+          <caret line="38" column="17" lean-forward="true" selection-start-line="38" selection-start-column="17" selection-end-line="38" selection-end-column="17" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/awsmobilejs/backend/cloud-api/playerstats/app.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="288">
+          <caret line="67" column="9" lean-forward="true" selection-start-line="67" selection-start-column="9" selection-end-line="67" selection-end-column="9" />
+          <folding>
+            <element signature="n#!!doc" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/pages/Admin.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="378">
+          <caret line="18" column="5" lean-forward="true" selection-start-line="18" selection-start-column="5" selection-end-line="18" selection-end-column="5" />
+          <folding>
+            <element signature="e#0#26#0" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/components/AdminStatsTable.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="326">
-          <caret line="154" column="40" selection-start-line="154" selection-start-column="40" selection-end-line="154" selection-end-column="40" />
+        <state relative-caret-position="470">
+          <caret line="26" column="16" lean-forward="true" selection-start-line="26" selection-start-column="16" selection-end-line="26" selection-end-column="16" />
           <folding>
             <element signature="e#0#26#0" expanded="true" />
-            <element signature="e#1494#3052#0" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/components/AdminSideMenu.js">
+    <entry file="file://$PROJECT_DIR$/src/pages/index.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="294">
-          <caret line="14" selection-start-line="14" selection-end-line="14" />
+        <state relative-caret-position="378">
+          <caret line="18" lean-forward="true" selection-start-line="18" selection-end-line="18" />
           <folding>
-            <element signature="e#0#26#0" expanded="true" />
+            <element signature="e#0#25#0" expanded="true" />
           </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/.gitignore">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="588">
+          <caret line="28" column="4" lean-forward="true" selection-start-line="28" selection-start-column="4" selection-end-line="28" selection-end-column="4" />
         </state>
       </provider>
     </entry>

--- a/src/components/AdminSideMenu.js
+++ b/src/components/AdminSideMenu.js
@@ -22,8 +22,8 @@ class AdminSideMenu extends React.Component {
 				defaultOpenKeys={['sub1']}
 				mode="inline"
 			>
-				<Menu.Item key="1">Game Stats</Menu.Item>
-				<Menu.Item key="2">Player Stats</Menu.Item>
+				<Menu.Item key="1">Game #153 Westlake September 15th, 2018</Menu.Item>
+				<Menu.Item key="2">Game #154 Westlake September 22th, 2018</Menu.Item>
 			</Menu>
 		);
 	}

--- a/src/components/AdminStatsTable.js
+++ b/src/components/AdminStatsTable.js
@@ -14,7 +14,7 @@ class AdminStatsTable extends React.Component {
 	}
 
 	componentDidUpdate(prevProps, prevState, snapshot) {
-		console.log('did update', { prevProps, prevState, snapshot });
+		//console.log('did update', { prevProps, prevState, snapshot });
 	}
 
 	handleSubmitData = () => {
@@ -23,26 +23,22 @@ class AdminStatsTable extends React.Component {
 	};
 
 	renderEditable = (cellInfo) => {
-		//console.log('cellInfo', cellInfo);
+		const isStatColumn = cellInfo.column.Header !== 'PLAYER';
 		return (
 			<div
-				contentEditable
-				suppressContentEditableWarning
-				onBlur={e => {
+				contentEditable={isStatColumn}
+				suppressContentEditableWarning={isStatColumn}
+				onKeyUp={e => {
 					const value = Number(e.target.innerHTML);
 					const data = [...this.state.data];
-					// maybe use onKeyUp or onChange instead to get value of e.which
-					// console.log('e which', e.which);
 
-					//if (isNaN(String.fromCharCode(e.which))) {
-					//	e.preventDefault();
-					//}
-					if (isNaN(value)) {
+					if (isNaN(value) && isStatColumn) {
 						e.preventDefault();
 						data[cellInfo.index][cellInfo.column.id] = '';
 					} else {
 						data[cellInfo.index][cellInfo.column.id] = e.target.innerHTML;
 					}
+
 					this.setState(() => ({ data }));
 				}}
 				dangerouslySetInnerHTML={{
@@ -149,7 +145,7 @@ class AdminStatsTable extends React.Component {
 					<Button
 						type="primary"
 						htmlType="button"
-						onChange={this.props.onSubmit}
+						onChange={this.handleSubmitData}
 					>
 						Submit
 					</Button>

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -34,6 +34,7 @@ const range = len => {
 const newPerson = (player) => {
 	return {
 		player,
+		gameId: '',
 		o: '',
 		"1b": '',
 		"2b": '',


### PR DESCRIPTION
This fixes:

- Names being erased when clicking in and out of the name cell
- Enter key doesn't work either so there's no accidental new line
